### PR TITLE
Seperate dependencies from Dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,9 +2,10 @@ FROM python:3
 
 WORKDIR /usr/src/app
 
-RUN python3 -m pip install --progress-bar off py-cord beautifulsoup4 requests google-generativeai
+COPY requirements.txt
+RUN python3 -m pip install --progress-bar off -r requirements.txt
 
-copy token.txt ./
+COPY token.txt ./
 COPY . .
 
 CMD ["python3", "./main.py"]


### PR DESCRIPTION
Dockerfile의 run문에서 디펜던시를 설치하는데, 이때 requirements.txt 파일을 읽지 않는 이슈가 있어서 수정하였습니다.